### PR TITLE
[Idea 💡] Add a team of developers to a new development environment and not only one developer

### DIFF
--- a/.github/workflows/workspace-initialization-when-issue-assigned.yml
+++ b/.github/workflows/workspace-initialization-when-issue-assigned.yml
@@ -172,7 +172,7 @@ jobs:
         echo "========== Add-AADSecurityGroupTeamToDataverseEnvironment =========="
         Import-Module ./Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1 -Force
 
-        Add-UserToDataverseEnvironment @Params -verbose
+        Add-AADSecurityGroupTeamToDataverseEnvironment @Params -verbose
       shell: powershell
   
   # Job for the import of the version of the solution in the main branch to the new Dataverse Dev environment

--- a/.github/workflows/workspace-initialization-when-issue-assigned.yml
+++ b/.github/workflows/workspace-initialization-when-issue-assigned.yml
@@ -296,7 +296,7 @@ jobs:
 
   # Job to add a comment on the issue with the dev branch name and the Dataverse Dev environment information
   add-comment-on-issue:
-    needs: [pre_job, import-solution-to-dev-environment]
+    needs: [pre_job, create-dataverse-dev-environment, import-solution-to-dev-environment]
     runs-on: ubuntu-latest
     env:
       RUNNER_DEBUG: 1
@@ -310,5 +310,7 @@ jobs:
         body: |
           # 🎆 Workspace initialized!
 
-          Branch: [**${{ needs.pre_job.outputs.development-branch-name }}**](${{ github.server.url }}/${{ github.repository }}/tree/${{ needs.pre_job.outputs.development-branch-name }})
-          Dataverse Dev environment created: [**${{ needs.pre_job.outputs.development-environment-display-name }}**](https://${{ needs.pre_job.outputs.development-environment-domain-name }}.${{ needs.pre_job.outputs.environment-url-region-code }}.dynamics.com)
+          - Branch: [**${{ needs.pre_job.outputs.development-branch-name }}**](${{ github.server.url }}/${{ github.repository }}/tree/${{ needs.pre_job.outputs.development-branch-name }})
+          - Dataverse Dev environment created:
+             - [**Power Apps Maker Portal - ${{ needs.pre_job.outputs.development-environment-display-name }}**](https://make.preview.powerapps.com/environments/${{ needs.create-dataverse-dev-environment.outputs.development-environment-id }}/solutions)
+             - [**${{ needs.pre_job.outputs.development-environment-display-name }}**](https://${{ needs.pre_job.outputs.development-environment-domain-name }}.${{ needs.pre_job.outputs.environment-url-region-code }}.dynamics.com)

--- a/.github/workflows/workspace-initialization-when-issue-assigned.yml
+++ b/.github/workflows/workspace-initialization-when-issue-assigned.yml
@@ -18,7 +18,6 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
       development-branch-name: ${{ steps.get-configurations.outputs.development-branch-name-base }}${{ github.event.issue.number }}
       environment-region: ${{ steps.get-configurations.outputs.environment-region }}
-      environment-url-region-code: ${{ steps.get-configurations.outputs.environment-url-region-code }}
       environment-language-display-name: ${{ steps.get-configurations.outputs.environment-language-display-name }}
       environment-currency-name: ${{ steps.get-configurations.outputs.environment-currency-name }}
       development-environment-display-name: ${{ steps.get-configurations.outputs.development-environment-display-name-base }}${{ github.event.issue.number }}
@@ -145,7 +144,7 @@ jobs:
           TenantId = "${{ secrets.TENANT_ID }}"
           ClientId = "${{ secrets.APPLICATION_ID }}"
           ClientSecret = "${{ secrets.CLIENT_SECRET }}"
-          DataverseEnvironmentUrl = "https://${{ needs.pre_job.outputs.development-environment-domain-name }}.${{ needs.pre_job.outputs.environment-url-region-code }}.dynamics.com"
+          DataverseEnvironmentUrl = "${{ needs.create-dataverse-dev-environment.outputs.development-environment-url }}"
           AzureADSecurityGroupName = "${{ needs.pre_job.outputs.developers-azure-ad-group-name }}"
         }
 
@@ -157,7 +156,7 @@ jobs:
   
   # Job for the import of the version of the solution in the main branch to the new Dataverse Dev environment
   import-solution-to-dev-environment:
-    needs: [pre_job, add-developers-to-dev-environment]
+    needs: [pre_job, create-dataverse-dev-environment, add-developers-to-dev-environment]
     environment:
       name: development
     runs-on: windows-latest
@@ -276,7 +275,7 @@ jobs:
         app-id: ${{ secrets.APPLICATION_ID }}
         client-secret: ${{ secrets.CLIENT_SECRET }}
         tenant-id: ${{ secrets.TENANT_ID }}
-        environment-url: https://${{ needs.pre_job.outputs.development-environment-domain-name }}.${{ needs.pre_job.outputs.environment-url-region-code }}.dynamics.com
+        environment-url: ${{ needs.create-dataverse-dev-environment.outputs.development-environment-url }}
         solution-file: out/Solutions/${{ env.solution_name }}.zip
         force-overwrite: true
         publish-changes: true

--- a/.github/workflows/workspace-initialization-when-issue-assigned.yml
+++ b/.github/workflows/workspace-initialization-when-issue-assigned.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: windows-latest
     outputs:
       development-environment-url: ${{ steps.create-dev-environment.outputs.environment-url }}
-      development-environment-id: ${{ steps.create-dev-environment.outputs.environment-id }}
+      powerappsmaker-development-environment-url: https://make.preview.powerapps.com/environments/${{ steps.create-dev-environment.outputs.environment-id }}/solutions
     env:
       dataverse_environment_sku: Sandbox # SKU for the new Dataverse Dev environment (Allowed values: Production, Sandbox, Trial or SubscriptionBasedTrial)
       RUNNER_DEBUG: 1
@@ -121,6 +121,7 @@ jobs:
     needs: [pre_job, create-issue-development-branch, create-dataverse-dev-environment]
     environment:
       name: development
+      url: ${{ needs.create-dataverse-dev-environment.outputs.powerappsmaker-development-environment-url }}
     runs-on: windows-latest
     env:
       RUNNER_DEBUG: 1
@@ -159,6 +160,7 @@ jobs:
     needs: [pre_job, create-dataverse-dev-environment, add-developers-to-dev-environment]
     environment:
       name: development
+      url: ${{ needs.create-dataverse-dev-environment.outputs.powerappsmaker-development-environment-url }}
     runs-on: windows-latest
     env:
       solution_name: PowerPlatformALMWithGitHub # Name of the considered solution
@@ -311,5 +313,5 @@ jobs:
 
           - Branch: [**${{ needs.pre_job.outputs.development-branch-name }}**](${{ github.server.url }}/${{ github.repository }}/tree/${{ needs.pre_job.outputs.development-branch-name }})
           - Dataverse Dev environment created:
-             - [**Power Apps Maker Portal - ${{ needs.pre_job.outputs.development-environment-display-name }}**](https://make.preview.powerapps.com/environments/${{ needs.create-dataverse-dev-environment.outputs.development-environment-id }}/solutions)
+             - [**Power Apps Maker Portal - ${{ needs.pre_job.outputs.development-environment-display-name }}**](${{ needs.create-dataverse-dev-environment.outputs.powerappsmaker-development-environment-url }})
              - [**${{ needs.pre_job.outputs.development-environment-display-name }}**](${{ needs.create-dataverse-dev-environment.outputs.development-environment-url }})

--- a/.github/workflows/workspace-initialization-when-issue-assigned.yml
+++ b/.github/workflows/workspace-initialization-when-issue-assigned.yml
@@ -23,6 +23,7 @@ jobs:
       environment-currency-name: ${{ steps.get-configurations.outputs.environment-currency-name }}
       development-environment-display-name: ${{ steps.get-configurations.outputs.development-environment-display-name-base }}${{ github.event.issue.number }}
       development-environment-domain-name: ${{ steps.get-configurations.outputs.development-environment-domain-name-base }}${{ github.event.issue.number }}
+      developers-azure-ad-group-name: ${{ steps.get-configurations.outputs.developers-azure-ad-group-name }}
       pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
     env:
       RUNNER_DEBUG: 1
@@ -112,8 +113,8 @@ jobs:
         body: |
           🎉 Environment created!
 
-  # Job to add the developer to the new Developer Dataverse environment
-  add-user-to-dev-environment:
+  # Job to add the developers to the new Development Dataverse environment
+  add-developers-to-dev-environment:
     needs: [pre_job, create-issue-development-branch, create-dataverse-dev-environment]
     environment:
       name: development
@@ -141,7 +142,7 @@ jobs:
           ClientId = "${{ secrets.APPLICATION_ID }}"
           ClientSecret = "${{ secrets.CLIENT_SECRET }}"
           DataverseEnvironmentUrl = "https://${{ needs.pre_job.outputs.development-environment-domain-name }}.${{ needs.pre_job.outputs.environment-url-region-code }}.dynamics.com"
-          AzureADSecurityGroupName = "sg-roles-powerplatformadmin"
+          AzureADSecurityGroupName = "${{ needs.pre_job.outputs.developers-azure-ad-group-name }}"
         }
 
         echo "========== Add-AADSecurityGroupTeamToDataverseEnvironment =========="
@@ -152,7 +153,7 @@ jobs:
   
   # Job for the import of the version of the solution in the main branch to the new Dataverse Dev environment
   import-solution-to-dev-environment:
-    needs: [pre_job, add-user-to-dev-environment]
+    needs: [pre_job, add-developers-to-dev-environment]
     environment:
       name: development
     runs-on: windows-latest

--- a/.github/workflows/workspace-initialization-when-issue-assigned.yml
+++ b/.github/workflows/workspace-initialization-when-issue-assigned.yml
@@ -313,4 +313,4 @@ jobs:
           - Branch: [**${{ needs.pre_job.outputs.development-branch-name }}**](${{ github.server.url }}/${{ github.repository }}/tree/${{ needs.pre_job.outputs.development-branch-name }})
           - Dataverse Dev environment created:
              - [**Power Apps Maker Portal - ${{ needs.pre_job.outputs.development-environment-display-name }}**](https://make.preview.powerapps.com/environments/${{ needs.create-dataverse-dev-environment.outputs.development-environment-id }}/solutions)
-             - [**${{ needs.pre_job.outputs.development-environment-display-name }}**](https://${{ needs.pre_job.outputs.development-environment-domain-name }}.${{ needs.pre_job.outputs.environment-url-region-code }}.dynamics.com)
+             - [**${{ needs.pre_job.outputs.development-environment-display-name }}**](${{ needs.create-dataverse-dev-environment.outputs.development-environment-url }})

--- a/.github/workflows/workspace-initialization-when-issue-assigned.yml
+++ b/.github/workflows/workspace-initialization-when-issue-assigned.yml
@@ -128,31 +128,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ needs.pre_job.outputs.development-branch-name }}
-
-    # Add developer as user to environment
-    - name: Add developer as user to environment
-      run: |
-        echo "========== Install Microsoft.PowerApps.Administration.PowerShel module =========="
-        Install-Module -Name Microsoft.PowerApps.Administration.PowerShell -Scope CurrentUser -Force
-
-        echo "========== Install Microsoft.Xrm.Data.PowerShell module =========="
-        Install-Module Microsoft.Xrm.Data.PowerShell -Scope CurrentUser -Force
-
-        echo "========== Set params =========="
-        $Params = @{
-          TenantId = "${{ secrets.TENANT_ID }}"
-          ClientId = "${{ secrets.APPLICATION_ID }}"
-          ClientSecret = "${{ secrets.CLIENT_SECRET }}"
-          DataverseEnvironmentUrl = "https://${{ needs.pre_job.outputs.development-environment-domain-name }}.${{ needs.pre_job.outputs.environment-url-region-code }}.dynamics.com"
-          DataverseEnvironmentDisplayName = "${{ needs.pre_job.outputs.development-environment-display-name }}"
-          UserInternalEmail = "${{ secrets.DEVELOPER_INTERNAL_EMAIL }}"
-        }
-
-        echo "========== Add-UserToDataverseEnvironment =========="
-        Import-Module ./Scripts/Add-UserToDataverseEnvironment.ps1 -Force
-
-        Add-UserToDataverseEnvironment @Params -verbose
-      shell: powershell
     
     # Add Azure AD security group with developers as a team on the environment
     - name: Add developers through a team to the environment

--- a/.github/workflows/workspace-initialization-when-issue-assigned.yml
+++ b/.github/workflows/workspace-initialization-when-issue-assigned.yml
@@ -138,7 +138,7 @@ jobs:
         echo "========== Install Microsoft.Xrm.Data.PowerShell module =========="
         Install-Module Microsoft.Xrm.Data.PowerShell -Scope CurrentUser -Force
 
-        echo "==========  Set params =========="
+        echo "========== Set params =========="
         $Params = @{
           TenantId = "${{ secrets.TENANT_ID }}"
           ClientId = "${{ secrets.APPLICATION_ID }}"
@@ -148,8 +148,29 @@ jobs:
           UserInternalEmail = "${{ secrets.DEVELOPER_INTERNAL_EMAIL }}"
         }
 
-        echo "==========  Add-UserToDataverseEnvironment =========="
+        echo "========== Add-UserToDataverseEnvironment =========="
         Import-Module ./Scripts/Add-UserToDataverseEnvironment.ps1 -Force
+
+        Add-UserToDataverseEnvironment @Params -verbose
+      shell: powershell
+    
+    # Add Azure AD security group with developers as a team on the environment
+    - name: Add developers through a team to the environment
+      run: |
+        echo "========== Install Microsoft.Xrm.Data.PowerShell module =========="
+        Install-Module Microsoft.Xrm.Data.PowerShell -Scope CurrentUser -Force
+
+        echo "========== Set params =========="
+        $Params = @{
+          TenantId = "${{ secrets.TENANT_ID }}"
+          ClientId = "${{ secrets.APPLICATION_ID }}"
+          ClientSecret = "${{ secrets.CLIENT_SECRET }}"
+          DataverseEnvironmentUrl = "https://${{ needs.pre_job.outputs.development-environment-domain-name }}.${{ needs.pre_job.outputs.environment-url-region-code }}.dynamics.com"
+          AzureADSecurityGroupName = "sg-roles-powerplatformadmin"
+        }
+
+        echo "========== Add-AADSecurityGroupTeamToDataverseEnvironment =========="
+        Import-Module ./Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1 -Force
 
         Add-UserToDataverseEnvironment @Params -verbose
       shell: powershell

--- a/.github/workflows/workspace-initialization-when-issue-assigned.yml
+++ b/.github/workflows/workspace-initialization-when-issue-assigned.yml
@@ -78,6 +78,9 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: windows-latest
+    outputs:
+      development-environment-url: ${{ steps.create-dev-environment.outputs.environment-url }}
+      development-environment-id: ${{ steps.create-dev-environment.outputs.environment-id }}
     env:
       dataverse_environment_sku: Sandbox # SKU for the new Dataverse Dev environment (Allowed values: Production, Sandbox, Trial or SubscriptionBasedTrial)
       RUNNER_DEBUG: 1
@@ -86,6 +89,7 @@ jobs:
     # Create the new Dataverse Dev environment
     #   Microsoft action: https://github.com/microsoft/powerplatform-actions/blob/main/create-environment/action.yml
     - name: Create environment
+      id: create-dev-environment
       uses: microsoft/powerplatform-actions/create-environment@main
       with:
         app-id: ${{ secrets.APPLICATION_ID }}

--- a/Configurations/configurations.json
+++ b/Configurations/configurations.json
@@ -8,7 +8,7 @@
         "developmentEnvironment": {
             "displayNameBase": "BAFC - Raphael - Dev - ",
             "domainNameBase": "bafc-rpo-gh-dev-",
-            "developersAzureAdGroupName": ""
+            "developersAzureAdGroupName": "sg-roles-powerplatformadmin"
         },
         "buildEnvironment": {
             "displayNameBase": "BAFC - Raphael - Build - ",

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@
    - **DATAVERSE_VALIDATION_ENVIRONMENT_NAME**: Display name of the Power Platform Validation environment
    - **DATAVERSE_PRODUCTION_ENVIRONMENT_URL**: URL of the Power Platform Production environment
    - **DATAVERSE_PRODUCTION_ENVIRONMENT_NAME**: Display name of the Power Platform Production environment
-   - **DEVELOPER_INTERNAL_EMAIL**: Email used by the developer to connect to the Power Platform environments (*currently the GitHub workflow support only one developer*)
    - **SOLUTION_COMPONENTS_OWNER_EMAIL**: Email of the user considered for the ownership of solution components (*ex: cloud flows*)
 
 > *Note: You can find all the available values in the [Datacenter regions](https://docs.microsoft.com/en-us/power-platform/admin/new-datacenter-regions) documentation page.*

--- a/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
+++ b/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
@@ -144,7 +144,7 @@ Function Add-AADSecurityGroupTeamToDataverseEnvironment {
                 $azureAdSecurityGroupDataverseTeamId = New-CrmRecord -conn $connection -EntityLogicalName team -Fields $azureAdSecurityGroupDataverseTeamConfiguration
             }
             # Case only one team found for the provided name
-            else if ($dataverseTeamsCount -eq 1) {
+            elseif ($dataverseTeamsCount -eq 1) {
                 Write-Verbose "One Azure AD security group found for the provided name - Update it."
                 $azureAdSecurityGroupDataverseTeamId = $dataverseTeams.CrmRecords[0].teamid
 
@@ -171,7 +171,7 @@ Function Add-AADSecurityGroupTeamToDataverseEnvironment {
                 Add-CrmSecurityRoleToTeam -TeamId $azureAdSecurityGroupDataverseTeamId -SecurityRoleId $securityRoleId
             }
             # Case no security role found
-            else if ($securityRolesCount -eq 0) {
+            elseif ($securityRolesCount -eq 0) {
                 Throw "No security role found in the considered Dataverse environment."
             }
             else {
@@ -179,7 +179,7 @@ Function Add-AADSecurityGroupTeamToDataverseEnvironment {
             }
         }
         # Case no Azure AD security group found for the provided name
-        else if ($azureAdGroupsCount -eq 0) {
+        elseif ($azureAdGroupsCount -eq 0) {
             Throw "No Azure AD security group found with the following name: $AzureADSecurityGroupName"
         }
         # Case more than one Azure AD security group found for the provided name

--- a/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
+++ b/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
@@ -84,13 +84,108 @@ Function Add-AADSecurityGroupTeamToDataverseEnvironment {
     Begin{}
 
     Process{
+        # Set variables
+        Write-Verbose "Set variables."
+        $aadSecurityGroupTeamType = New-CrmOptionSetValue -Value 2
+        
         # Connect to Azure CLI with service principal
         Write-Verbose "Connect to Azure CLI with service principal."
         az login --service-principal -u $ClientId -p $ClientSecret --tenant $TenantId --allow-no-subscriptions
 
         # Search the considered Azure AD security group based on the provided name
         Write-Verbose "Search the considered Azure AD security group based on the provided name: $AzureADSecurityGroupName"
-        $groups = az ad group list --filter "displayname eq '$AzureADSecurityGroupName'"
+        $azureAdGroups = az ad group list --filter "displayname eq '$AzureADSecurityGroupName'" | ConvertFrom-Json
+
+        # Number of groups found
+        $azureAdGroupsMeasure = $azureAdGroups | Measure
+        $azureAdGroupsCount = $azureAdGroupsMeasure.Count
+
+        # Case only one Azure AD security group found for the provided name
+        if ($azureAdGroupsCount -eq 1) {
+            Write-Verbose "Only one Azure AD security group found for the provided name - We continue."
+            Write-Verbose "Get the object id of the group found."
+            $azureAdSecurityGroupId = $azureAdGroups[0].objectId
+
+            # Connect to Microsoft.Xrm.Data.PowerShell with service principal
+            Write-Verbose "Connect to Microsoft.Xrm.Data.PowerShell with service principal."
+            $connection = Connect-CrmOnline -ServerUrl $DataverseEnvironmentUrl -OAuthClientId $ClientId -ClientSecret $ClientSecret
+
+            # Get the business unit ID of the of the account we are connected with
+            Write-Verbose "Get the business unit ID of the of the account we are connected with."
+            $businessUnitId = (Invoke-CrmWhoAmI).BusinessUnitId
+
+            # Set Fetch query variable for the search the security role details for the business unit of the account used to logged in
+            $fetchSecurityRoles = @"
+<fetch version="1.0" output-format="xml-platform" mapping="logical" distinct="false" no-lock="true">
+    <entity name="role">
+        <attribute name="roleid" />
+        <filter type="and">
+            <condition attribute="name" operator="eq" value="{0}" />
+            <condition attribute="businessunitid" operator="eq" value="{1}" />
+        </filter>
+    </entity>
+</fetch>
+"@
+            $fetchSecurityRoles = $fetchSecurityRoles -F $SecurityRoleName, $businessUnitId
+
+            # Search the considered Azure AD security group in the teams of the Dataverse environment base on the provided name
+            Write-Verbose "Search the considered Azure AD security group in the teams of the Dataverse environment based on the provided name: $AzureADSecurityGroupName"
+            $dataverseTeams = Get-CrmRecords -conn $connection -EntityLogicalName team -FilterAttribute "name" -FilterOperator "eq" -FilterValue $AzureADSecurityGroupName -Fields teamid
+
+            # Number of teams found in the Dataverse environment
+            $dataverseTeamsCount = $dataverseTeams.Count
+
+            # Configuration of the Azure AD security group team in Dataverse
+            $azureAdSecurityGroupDataverseTeamConfiguration = @{ "name"=$AzureADSecurityGroupName;"teamtype"=$aadSecurityGroupTeamType;"azureactivedirectoryobjectid"=[guid]$azureAdSecurityGroupId }
+
+            # Case no team found for the provided name
+            if ($dataverseTeamsCount -eq 0) {
+                Write-Verbose "No Azure AD security group found for the provided name - Create it."
+                $azureAdSecurityGroupDataverseTeamId = New-CrmRecord -conn $connection -EntityLogicalName team -Fields $azureAdSecurityGroupDataverseTeamConfiguration
+            }
+            # Case only one team found for the provided name
+            else if ($dataverseTeamsCount -eq 1) {
+                Write-Verbose "One Azure AD security group found for the provided name - Update it."
+                $azureAdSecurityGroupDataverseTeamId = $dataverseTeams.CrmRecords[0].teamid
+
+                Set-CrmRecord -conn $connection -EntityLogicalName team -Id $azureAdSecurityGroupDataverseTeamId -Fields $azureAdSecurityGroupDataverseTeamConfiguration
+            }
+            # Case more than one team found for the provided name
+            else {
+                Throw "Multiple teams found for the following Azure AD security group: $AzureADSecurityGroupName"
+            }
+
+            # Search security roles with the provided name and for the business unit of the logged in user (should be root)
+            Write-Verbose "Search security roles with the following information: SecurityRoleName is $SecurityRoleName and BusinessUnitId is $businessUnitId"
+            $securityRoles = Get-CrmRecordsByFetch -Fetch $fetchSecurityRoles
+
+            # Number of teams found in the Dataverse environment
+            $securityRolesCount = $securityRoles.Count
+
+            # Case only one security role found
+            if ($securityRolesCount -eq 1) {
+                Write-Verbose "One security role found."
+                $securityRoleId = $securityRoles.CrmRecords[0].roleid.Guid
+
+                Write-Verbose "Assign security role to the Azure AD security group team."
+                Add-CrmSecurityRoleToTeam -TeamId $azureAdSecurityGroupDataverseTeamId -SecurityRoleId $securityRoleId
+            }
+            # Case no security role found
+            else if ($securityRolesCount -eq 0) {
+                Throw "No security role found in the considered Dataverse environment."
+            }
+            else {
+                Throw "More than one security role found in the considered Dataverse environment."
+            }
+        }
+        # Case no Azure AD security group found for the provided name
+        else if ($azureAdGroupsCount -eq 0) {
+            Throw "No Azure AD security group found with the following name: $AzureADSecurityGroupName"
+        }
+        # Case more than one Azure AD security group found for the provided name
+        else {
+            Throw "More than one Azure AD security group found with the following name: $AzureADSecurityGroupName"
+        }
     }
 
     End{}

--- a/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
+++ b/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
@@ -75,7 +75,7 @@ Function Add-AADSecurityGroupTeamToDataverseEnvironment {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String]$AzureADSecurityGroupName,
-        
+
         # Name of the security role to assign to the new user
         [Parameter()]
         [String]$SecurityRoleName="System Administrator"
@@ -87,7 +87,7 @@ Function Add-AADSecurityGroupTeamToDataverseEnvironment {
         # Set variables
         Write-Verbose "Set variables."
         $aadSecurityGroupTeamType = New-CrmOptionSetValue -Value 2
-        
+
         # Connect to Azure CLI with service principal
         Write-Verbose "Connect to Azure CLI with service principal."
         az login --service-principal -u $ClientId -p $ClientSecret --tenant $TenantId --allow-no-subscriptions

--- a/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
+++ b/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
@@ -1,0 +1,91 @@
+# Copyright (c) 2020 Raphael Pothin.
+# Licensed under the MIT License.
+
+Function Add-AADSecurityGroupTeamToDataverseEnvironment {
+    <#
+        .SYNOPSIS
+            Add an Azure AD Security Group Team to a Dataverse environment
+
+        .DESCRIPTION
+            Add an Azure AD Security Group Team to a Dataverse environment and assign the provided security role.
+
+        .PARAMETER TenantId
+            ID of the tenant where the targeted Dataverse environment is.
+
+        .PARAMETER ClientId
+            Client ID of the Azure AD application registration associated to the application user with the System Administrator security role in the targeted Dataverse environment.
+
+        .PARAMETER ClientSecret
+            Client Secret of the Azure AD application registration associated to the application user with the System Administrator security role in the targeted Dataverse environment.
+
+        .PARAMETER DataverseEnvironmentUrl
+            URL of the targeted Dataverse environment.
+
+        .PARAMETER AzureADSecurityGroupName
+            Name of the Azure AD Security Group to add as a team to the considered Dataverse environment.
+
+        .PARAMETER SecurityRoleName
+            Specifies the name of the security role you want to assign to the Azure AD Security Group team you will add to the considered Dataverse environment.
+
+        .INPUTS
+            None. You cannot pipe objects to Add-AADSecurityGroupTeamToDataverseEnvironment.
+
+        .OUTPUTS
+            None.
+
+        .EXAMPLE
+            PS> Add-AADSecurityGroupTeamToDataverseEnvironment -TenantId "00000000-0000-0000-0000-000000000000" -ClientId "00000000-0000-0000-0000-000000000000" -ClientSecret "clientSecretSample" -DataverseEnvironmentUrl "https://demo.crm3.dynamics.com/" -AzureADSecurityGroupName "SG-POWERPLATFORM-DEVELOPERS-DEMO"
+
+        .LINK
+            README.md: https://github.com/rpothin/PowerPlatform-ALM-With-GitHub-Template/blob/main/README.md
+
+        .NOTES
+            * This function does not work for now whith PowerShell 7 / Core
+            * You need to have the following PowerShell modules installed to be able to use this function: Azure CLI, Microsoft.PowerApps.Administration.PowerShell, Microsoft.Xrm.Data.PowerShell
+            * Do not forget to register the considered Azure AD application registration using the "New-PowerAppManagementApp" (Microsoft.PowerApps.Administration.PowerShell)
+    #>
+
+    [CmdletBinding()]
+    Param (
+        # ID of the tenant where the targeted Dataverse environment is
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]$TenantId,
+
+        # Client ID of the Azure AD application registration
+        # associated to the application user with the System Administrator security role
+        # in the targeted Dataverse environment
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]$ClientId,
+
+        # Client Secret of the Azure AD application registration
+        # associated to the application user with the System Administrator security role
+        # in the targeted Dataverse environment
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]$ClientSecret,
+
+        # URL of the targeted Dataverse environment
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]$DataverseEnvironmentUrl,
+
+        # Name of the Azure AD Security Group to add to the Dataverse environment
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]$AzureADSecurityGroupName,
+        
+        # Name of the security role to assign to the new user
+        [Parameter()]
+        [String]$SecurityRoleName="System Administrator"
+    )
+
+    Begin{}
+
+    Process{
+        
+    }
+
+    End{}
+}

--- a/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
+++ b/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
@@ -84,7 +84,13 @@ Function Add-AADSecurityGroupTeamToDataverseEnvironment {
     Begin{}
 
     Process{
-        
+        # Connect to Azure CLI with service principal
+        Write-Verbose "Connect to Azure CLI with service principal."
+        az login --service-principal -u $ClientId -p $ClientSecret --tenant $TenantId --allow-no-subscriptions
+
+        # Search the considered Azure AD security group based on the provided name
+        Write-Verbose "Search the considered Azure AD security group based on the provided name: $AzureADSecurityGroupName"
+        $groups = az ad group list --filter "displayname eq '$AzureADSecurityGroupName'"
     }
 
     End{}

--- a/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
+++ b/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
@@ -97,7 +97,7 @@ Function Add-AADSecurityGroupTeamToDataverseEnvironment {
         $azureAdGroups = az ad group list --filter "displayname eq '$AzureADSecurityGroupName'" | ConvertFrom-Json
 
         # Number of groups found
-        $azureAdGroupsMeasure = $azureAdGroups | Measure
+        $azureAdGroupsMeasure = $azureAdGroups | Measure-Object
         $azureAdGroupsCount = $azureAdGroupsMeasure.Count
 
         # Case only one Azure AD security group found for the provided name

--- a/Scripts/Add-UserToDataverseEnvironment.ps1
+++ b/Scripts/Add-UserToDataverseEnvironment.ps1
@@ -34,7 +34,7 @@ Function Add-UserToDataverseEnvironment {
             None. You cannot pipe objects to Add-UserToDataverseEnvironment.
 
         .OUTPUTS
-            Object. Add-UserToDataverseEnvironment returns the details of of the operation of adding the user to the targeted Dataverse environment.
+            None.
 
         .EXAMPLE
             PS> Add-UserToDataverseEnvironment -TenantId "00000000-0000-0000-0000-000000000000" -ClientId "00000000-0000-0000-0000-000000000000" -ClientSecret "clientSecretSample" -DataverseEnvironmentUrl "https://demo.crm3.dynamics.com/" -DataverseEnvironmentDisplayName "Demo" -UserInternalEmail "user.demo@demo.com"

--- a/Scripts/Enable-CloudFlows.ps1
+++ b/Scripts/Enable-CloudFlows.ps1
@@ -28,7 +28,7 @@ Function Enable-CloudFlows {
             None. You cannot pipe objects to Enable-CloudFlows.
 
         .OUTPUTS
-            Object. Enable-CloudFlows returns the result of the operation of enabling Cloud Flows in the targeted Dataverse environment.
+            None.
 
         .EXAMPLE
             PS> Enable-CloudFlows -ClientId "00000000-0000-0000-0000-000000000000" -ClientSecret "clientSecretSample" -DataverseEnvironmentUrl "https://demo.crm3.dynamics.com/" -SolutionName "Demo" -SolutionComponentsOwnerEmail "demo.user@demo.com"

--- a/Scripts/Grant-GroupsAccessToCanvasApps.ps1
+++ b/Scripts/Grant-GroupsAccessToCanvasApps.ps1
@@ -31,7 +31,7 @@ Function Grant-GroupsAccessToCanvasApps {
             None. You cannot pipe objects to Grant-GroupsAccessToCanvasApps.
 
         .OUTPUTS
-            Object. Grant-GroupsAccessToCanvasApps returns the result of the operation of giving access to canvas apps to Azure AD groups in the targeted Dataverse environment.
+            None.
 
         .EXAMPLE
             PS> Grant-GroupsAccessToCanvasApps -ClientId "00000000-0000-0000-0000-000000000000" -ClientSecret "clientSecretSample" -DataverseEnvironmentUrl "https://demo.crm3.dynamics.com/" -DataverseEnvironmentDisplayName "Demo" -ConfigurationFilePath ".\CanvasAppsGroupsAccessMapping.json"


### PR DESCRIPTION
# Description

Until now, we were only able to add one developer based on an email stored as a secret to a development environment created during the workspace initialization phase.
With this pull request, we replace this part by adding an Azure AD security group (provided in the configuration file) as a team in the development environment automatically giving System Administrator security role to the members.

Note: I also started some new exploration work regarding the #146 issue.

Fixed issues:
- #154 

## Type of change

<Please check the options that are relevant.>

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.>

- [x] Tested in [PowerPlatform-ALM-With-GitHub-Template-Demo](https://github.com/rpothin/PowerPlatform-ALM-With-GitHub-Template-Demo) repository with the considered secrets removed

# Checklist

<We encourage you to check all the options below before submitting your pull request.
This will help us verify it more quickly.>

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
