### PR TITLE
[Idea 💡] Use "environment-url" output of the "create-environment" action in workflows

### DIFF
--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -79,8 +79,7 @@ jobs:
     needs: pre_job
     runs-on: ubuntu-latest
     outputs:
-      dataverse_build_environment_domain_name: ${{ steps.dataverse_build_environment_domain_name.outputs.dataverse_build_environment_domain_name }}
-      environment-url-region-code: ${{ steps.get-configurations.outputs.environment-url-region-code }}
+      build-environment-url: ${{ steps.create-build-environment.outputs.environment-url }}
       pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
     env:
       dataverse_environment_sku: Sandbox # SKU for the new Dataverse Dev environment (Allowed values: Production, Sandbox, Trial or SubscriptionBasedTrial)
@@ -111,12 +110,13 @@ jobs:
       run: |
         $dataverseBuildEnvironmentDomainName = "${{ steps.get-configurations.outputs.build-environment-domain-name-base }}${{ needs.pre_job.outputs.current-date }}-${{ github.run_number }}"
         
-        echo "::set-output name=dataverse_build_environment_domain_name::$dataverseBuildEnvironmentDomainName"
+        echo "dataverse_build_environment_domain_name=$dataverseBuildEnvironmentDomainName" >> $Env:GITHUB_ENV
       shell: pwsh
 
     # Create the just in time Dataverse Build environment
     #   Microsoft action: https://github.com/microsoft/powerplatform-actions/blob/main/create-environment/action.yml
     - name: Create environment
+      id: create-build-environment
       uses: microsoft/powerplatform-actions/create-environment@main
       with:
         app-id: ${{ secrets.APPLICATION_ID }}
@@ -127,7 +127,7 @@ jobs:
         type: ${{ env.dataverse_environment_sku }}
         currency: ${{ steps.get-configurations.outputs.environment-currency-name }}
         language: ${{ steps.get-configurations.outputs.environment-language-display-name }}
-        domain: ${{ steps.dataverse_build_environment_domain_name.outputs.dataverse_build_environment_domain_name }}
+        domain: ${{ env.dataverse_build_environment_domain_name }}
   
   # Job to build a managed solution in the just in time Dataverse Build environment
   build-managed-solution:
@@ -231,7 +231,7 @@ jobs:
         app-id: ${{ secrets.APPLICATION_ID }}
         client-secret: ${{ secrets.CLIENT_SECRET }}
         tenant-id: ${{ secrets.TENANT_ID }}
-        environment-url: "https://${{ needs.create-build-environment.outputs.dataverse_build_environment_domain_name }}.${{ needs.create-build-environment.outputs.environment-url-region-code }}.dynamics.com"
+        environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
         solution-file: ${{ env.path_to_solution_zip_file }}
         force-overwrite: true
         publish-changes: true
@@ -248,7 +248,7 @@ jobs:
         app-id: ${{ secrets.APPLICATION_ID }}
         client-secret: ${{ secrets.CLIENT_SECRET }}
         tenant-id: ${{ secrets.TENANT_ID }}
-        environment-url: https://${{ needs.create-build-environment.outputs.dataverse_build_environment_domain_name }}.${{ needs.create-build-environment.outputs.environment-url-region-code }}.dynamics.com
+        environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
         solution-name: ${{ env.solution_name }}
         solution-output-file: out/Solutions/${{ env.solution_name }}_managed.zip
         managed: true
@@ -278,7 +278,7 @@ jobs:
         app-id: ${{ secrets.APPLICATION_ID }}
         client-secret: ${{ secrets.CLIENT_SECRET }}
         tenant-id: ${{ secrets.TENANT_ID }}
-        environment-url: https://${{ needs.create-build-environment.outputs.dataverse_build_environment_domain_name }}.${{ needs.create-build-environment.outputs.environment-url-region-code }}.dynamics.com
+        environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
 
   # Job to delete the release branch if solution deployment to Dataverse Build environment fails
   delete-release-branch:

--- a/.github/workflows/import-solution-to-validation.yml
+++ b/.github/workflows/import-solution-to-validation.yml
@@ -31,8 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       current-date: ${{ steps.current_date.outputs.NOW }}
-      dataverse_build_environment_domain_name: ${{ steps.dataverse_build_environment_domain_name.outputs.dataverse_build_environment_domain_name }}
-      environment-url-region-code: ${{ steps.get-configurations.outputs.environment-url-region-code }}
+      build-environment-url: ${{ steps.create-build-environment.outputs.environment-url }}
       pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
     env:
       dataverse_environment_sku: Sandbox # SKU for the new Dataverse Dev environment (Allowed values: Production, Sandbox, Trial or SubscriptionBasedTrial)
@@ -69,7 +68,7 @@ jobs:
       run: |
         $dataverseBuildEnvironmentDomainName = "${{ steps.get-configurations.outputs.build-environment-domain-name-base }}${{ steps.current_date.outputs.NOW }}-${{ github.run_number }}"
         
-        echo "::set-output name=dataverse_build_environment_domain_name::$dataverseBuildEnvironmentDomainName"
+        echo "dataverse_build_environment_domain_name=$dataverseBuildEnvironmentDomainName" >> $Env:GITHUB_ENV
       shell: pwsh
 
     # Create the just in time Dataverse Build environment
@@ -85,7 +84,7 @@ jobs:
         type: ${{ env.dataverse_environment_sku }}
         currency: ${{ steps.get-configurations.outputs.environment-currency-name }}
         language: ${{ steps.get-configurations.outputs.environment-language-display-name }}
-        domain: ${{ steps.dataverse_build_environment_domain_name.outputs.dataverse_build_environment_domain_name }}
+        domain: ${{ env.dataverse_build_environment_domain_name }}
   
   # Job to build a managed solution in the just in time Dataverse Build environment
   build-managed-solution:
@@ -174,7 +173,7 @@ jobs:
         app-id: ${{ secrets.APPLICATION_ID }}
         client-secret: ${{ secrets.CLIENT_SECRET }}
         tenant-id: ${{ secrets.TENANT_ID }}
-        environment-url: "https://${{ needs.create-build-environment.outputs.dataverse_build_environment_domain_name }}.${{ needs.create-build-environment.outputs.environment-url-region-code }}.dynamics.com"
+        environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
         solution-file: ${{ env.path_to_solution_zip_file }}
         force-overwrite: true
         publish-changes: true
@@ -191,7 +190,7 @@ jobs:
         app-id: ${{ secrets.APPLICATION_ID }}
         client-secret: ${{ secrets.CLIENT_SECRET }}
         tenant-id: ${{ secrets.TENANT_ID }}
-        environment-url: https://${{ needs.create-build-environment.outputs.dataverse_build_environment_domain_name }}.${{ needs.create-build-environment.outputs.environment-url-region-code }}.dynamics.com
+        environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
         solution-name: ${{ env.solution_name }}
         solution-output-file: out/ship/${{ env.solution_name }}.zip
         managed: true
@@ -301,4 +300,4 @@ jobs:
         app-id: ${{ secrets.APPLICATION_ID }}
         client-secret: ${{ secrets.CLIENT_SECRET }}
         tenant-id: ${{ secrets.TENANT_ID }}
-        environment-url: https://${{ needs.create-build-environment.outputs.dataverse_build_environment_domain_name }}.${{ needs.create-build-environment.outputs.environment-url-region-code }}.dynamics.com
+        environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}

--- a/.github/workflows/import-solution-to-validation.yml
+++ b/.github/workflows/import-solution-to-validation.yml
@@ -74,6 +74,7 @@ jobs:
     # Create the just in time Dataverse Build environment
     #   Microsoft action: https://github.com/microsoft/powerplatform-actions/blob/main/create-environment/action.yml
     - name: Create environment
+      id: create-build-environment
       uses: microsoft/powerplatform-actions/create-environment@main
       with:
         app-id: ${{ secrets.APPLICATION_ID }}

--- a/.github/workflows/solution-quality-check-on-pr.yml
+++ b/.github/workflows/solution-quality-check-on-pr.yml
@@ -27,8 +27,8 @@ jobs:
   create-build-environment:
     runs-on: ubuntu-latest
     outputs:
-      pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
       build-environment-url: ${{ steps.create-build-environment.outputs.environment-url }}
+      pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
     env:
       dataverse_environment_sku: Sandbox # SKU for the new Dataverse Dev environment (Allowed values: Production, Sandbox, Trial or SubscriptionBasedTrial)
       RUNNER_DEBUG: 1

--- a/.github/workflows/solution-quality-check-on-pr.yml
+++ b/.github/workflows/solution-quality-check-on-pr.yml
@@ -27,9 +27,8 @@ jobs:
   create-build-environment:
     runs-on: ubuntu-latest
     outputs:
-      dataverse_build_environment_domain_name: ${{ steps.dataverse_build_environment_domain_name.outputs.dataverse_build_environment_domain_name }}
-      environment-url-region-code: ${{ steps.get-configurations.outputs.environment-url-region-code }}
       pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
+      build-environment-url: ${{ steps.create-build-environment.outputs.environment-url }}
     env:
       dataverse_environment_sku: Sandbox # SKU for the new Dataverse Dev environment (Allowed values: Production, Sandbox, Trial or SubscriptionBasedTrial)
       RUNNER_DEBUG: 1
@@ -65,12 +64,13 @@ jobs:
       run: |
         $dataverseBuildEnvironmentDomainName = "${{ steps.get-configurations.outputs.build-environment-domain-name-base }}${{ env.NOW }}-${{ github.run_number }}"
         
-        echo "::set-output name=dataverse_build_environment_domain_name::$dataverseBuildEnvironmentDomainName"
+        echo "dataverse_build_environment_domain_name=$dataverseBuildEnvironmentDomainName" >> $Env:GITHUB_ENV
       shell: pwsh
 
     # Create the just in time Dataverse Build environment
     #   Microsoft action: https://github.com/microsoft/powerplatform-actions/blob/main/create-environment/action.yml
     - name: Create environment
+      id: create-build-environment
       uses: microsoft/powerplatform-actions/create-environment@main
       with:
         app-id: ${{ secrets.APPLICATION_ID }}
@@ -81,7 +81,7 @@ jobs:
         type: ${{ env.dataverse_environment_sku }}
         currency: ${{ steps.get-configurations.outputs.environment-currency-name }}
         language: ${{ steps.get-configurations.outputs.environment-language-display-name }}
-        domain: ${{ steps.dataverse_build_environment_domain_name.outputs.dataverse_build_environment_domain_name }}
+        domain: ${{ env.dataverse_build_environment_domain_name }}
   
   # Job a for simple quality checks on the considered solution
   solution-quality-checks:
@@ -252,7 +252,7 @@ jobs:
         app-id: ${{ secrets.APPLICATION_ID }}
         client-secret: ${{ secrets.CLIENT_SECRET }}
         tenant-id: ${{ secrets.TENANT_ID }}
-        environment-url: https://${{ needs.create-build-environment.outputs.dataverse_build_environment_domain_name }}.${{ needs.create-build-environment.outputs.environment-url-region-code }}.dynamics.com
+        environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
         solution-file: ${{ env.path_to_solution_zip_file }}
         force-overwrite: true
         publish-changes: true
@@ -270,7 +270,7 @@ jobs:
         app-id: ${{ secrets.APPLICATION_ID }}
         client-secret: ${{ secrets.CLIENT_SECRET }}
         tenant-id: ${{ secrets.TENANT_ID }}
-        environment-url: https://${{ needs.create-build-environment.outputs.dataverse_build_environment_domain_name }}.${{ needs.create-build-environment.outputs.environment-url-region-code }}.dynamics.com
+        environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
         solution-name: ${{ env.solution_name }}
         solution-output-file: out/ship/${{ env.solution_name }}.zip
         managed: true
@@ -301,7 +301,7 @@ jobs:
         app-id: ${{ secrets.APPLICATION_ID }}
         client-secret: ${{ secrets.CLIENT_SECRET }}
         tenant-id: ${{ secrets.TENANT_ID }}
-        environment-url: https://${{ needs.create-build-environment.outputs.dataverse_build_environment_domain_name }}.${{ needs.create-build-environment.outputs.environment-url-region-code }}.dynamics.com
+        environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
         
     # Run a command that will failed if too many Medium or High severity points in the results of the solution checker execution to stop the run
     - name: Exit if too many notable points in solution checker results


### PR DESCRIPTION
# Description

The [microsoft/powerplatform-actions/create-environment](https://github.com/microsoft/powerplatform-actions/blob/main/create-environment/action.yml) action comes with an "environment-url" output. In this pull request we updated the workflows where we create an environment to take advantage of this output.

Fixed issues:
- #146 

## Type of change

<Please check the options that are relevant.>

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.>

- [x] Tested in [PowerPlatform-ALM-With-GitHub-Template-Demo](https://github.com/rpothin/PowerPlatform-ALM-With-GitHub-Template-Demo) repository with the considered secrets removed

# Checklist

<We encourage you to check all the options below before submitting your pull request.
This will help us verify it more quickly.>

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
