### PR TITLE
[Bug 🐜] Output schema of Azure CLI commands update and not consistent anymore

### DIFF
--- a/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
+++ b/Scripts/Add-AADSecurityGroupTeamToDataverseEnvironment.ps1
@@ -104,7 +104,7 @@ Function Add-AADSecurityGroupTeamToDataverseEnvironment {
         if ($azureAdGroupsCount -eq 1) {
             Write-Verbose "Only one Azure AD security group found for the provided name - We continue."
             Write-Verbose "Get the object id of the group found."
-            $azureAdSecurityGroupId = $azureAdGroups[0].objectId
+            $azureAdSecurityGroupId = $azureAdGroups[0].id
 
             # Connect to Microsoft.Xrm.Data.PowerShell with service principal
             Write-Verbose "Connect to Microsoft.Xrm.Data.PowerShell with service principal."

--- a/Scripts/Add-UserToDataverseEnvironment.ps1
+++ b/Scripts/Add-UserToDataverseEnvironment.ps1
@@ -109,7 +109,7 @@ Function Add-UserToDataverseEnvironment {
         if ($null -ne $user) {
             # Get the Object ID of the considered user
             Write-Verbose "Get user Object ID from the provided principal name."
-            $userObjectId = $user.objectId
+            $userObjectId = $user.id
 
             # Connect to Power Apps with service principal
             Write-Verbose "Connect to Power Apps with service principal."


### PR DESCRIPTION
# Description

The schema of the output of some Azure CLI commands (get users details, get groups details...) has recently changed impacting some PowerShell scripts. The updates of this pull request correct errors in the execution of these PowerShell scripts.

Fixed issues:
- #219 

## Type of change

<Please check the options that are relevant.>

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.>

- [x] Tested in [PowerPlatform-ALM-With-GitHub-Template-Demo](https://github.com/rpothin/PowerPlatform-ALM-With-GitHub-Template-Demo) repository with the updated workflows using the new reusable workflow

# Checklist

<We encourage you to check all the options below before submitting your pull request.
This will help us verify it more quickly.>

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
