### PR TITLE
[Idea 💡] Automate the configuration of Azure Application Insights Instrumentation Key in canvas apps

### DIFF
--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -38,6 +38,7 @@ runs:
           $configurations = Get-Content $ConfigurationFilePath -ErrorVariable getConfigurationError -ErrorAction Stop | ConvertFrom-Json
 
           $canvasAppsInstrumentationKey = $configurations.canvasApps.instrumentationKey
+          Write-Host "Canvas apps instrumentation key: $canvasAppsInstrumentationKey"
         }
         catch {
           Write-Error -Message "Error in the extraction of the canvas apps instrumentation key from the considered configuration file ($ConfigurationFilePath): $getConfigurationError" -ErrorAction Stop
@@ -45,10 +46,18 @@ runs:
 
         # For all relevant canvas apps (with an "AppInsightsKey.json" file) in the considered solution, set canvas apps instrumentation key
         Get-ChildItem -Path "Solutions/${{ inputs.solution-name }}/CanvasApps/src" -Recurse -Filter AppInsightsKey.json | 
-        ForEach-Object {     
+        ForEach-Object {
           $appInsightsKeyFilePath = $_.FullName
+          Write-Host "Set canvas apps instrumentation key for the following canvas app: $appInsightsKeyFilePath"
+
           $appInsightsKeyFileContent = Get-Content $appInsightsKeyFilePath | ConvertFrom-Json
-          $appInsightsKeyFileContent.InstrumentationKey = $canvasAppsInstrumentationKe
+          Write-Host "Canvas apps instrumentation key configuration before update:"
+          $appInsightsKeyFileContent
+
+          $appInsightsKeyFileContent.InstrumentationKey = $canvasAppsInstrumentationKey
+          Write-Host "Canvas apps instrumentation key configuration after update:"
+          $appInsightsKeyFileContent
+
           $appInsightsKeyFileContent | ConvertTo-Json | set-content $appInsightsKeyFilePath
         }
       shell: pwsh

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -90,5 +90,5 @@ runs:
         cd Solutions/${{ inputs.solution-name }}
 
         # Execute pac solution pack to generate the latest version of the the msapp files
-        pac solution pack --zipfile ${{ inputs.solution-name }}.zip --processCanvasApps
+        # pac solution pack --zipfile ${{ inputs.solution-name }}.zip --processCanvasApps
       shell: pwsh

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -90,5 +90,5 @@ runs:
         cd Solutions/${{ inputs.solution-name }}
 
         # Execute pac solution pack to generate the latest version of the the msapp files
-        # pac solution pack --zipfile ${{ inputs.solution-name }}.zip --processCanvasApps
+        pac solution pack --zipfile ${{ inputs.solution-name }}.zip --processCanvasApps
       shell: pwsh

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -63,6 +63,7 @@ runs:
         }
       shell: pwsh
 
+    # ⚠ WOARKAROUND regarding a potential issue in the pack of canvas apps with the current version of the out of the box action
     # "Microsoft.PowerApps.CLI" setup
     - name: PowerApps CLI setup
       run: |

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -3,7 +3,7 @@
 
 name: 'Set canvas apps instrumentation key'
 
-description: 'Set canvas apps instrumentation key based on a configuration for the considered environment'
+description: 'Set canvas apps instrumentation key based on a configuration for the considered solution and the considered environment'
 
 inputs:
   path-to-custom-deployment-settings-file:

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -60,7 +60,7 @@ runs:
         }
       shell: pwsh
 
-    # Check - Temp for test
+    # Manual pac solution pack with processCanvasApps
     - name: Check
       run:  |
         # For all relevant canvas apps (with an "AppInsightsKey.json" file) in the considered solution, set canvas apps instrumentation key

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -64,7 +64,7 @@ runs:
     - name: PowerApps CLI setup
       run: |
         $nugetPackage = "Microsoft.PowerApps.CLI"
-        $nugetPackageVersion = "1.10.4"
+        $nugetPackageVersion = "1.16.6"
         $outFolder = "pac"
 
         nuget install $nugetPackage -Version $nugetPackageVersion -OutputDirectory $outFolder

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -60,16 +60,30 @@ runs:
         }
       shell: pwsh
 
-    # Manual pac solution pack with processCanvasApps
-    - name: Check
-      run:  |
-        # For all relevant canvas apps (with an "AppInsightsKey.json" file) in the considered solution, set canvas apps instrumentation key
-        Get-ChildItem -Path "Solutions/${{ inputs.solution-name }}/CanvasApps/src" -Recurse -Filter AppInsightsKey.json | 
-        ForEach-Object {
-          $appInsightsKeyFilePath = $_.FullName
-          Write-Host "Set canvas apps instrumentation key for the following canvas app: $appInsightsKeyFilePath"
+    # "Microsoft.PowerApps.CLI" setup
+    - name: PowerApps CLI setup
+      run: |
+        $nugetPackage = "Microsoft.PowerApps.CLI"
+        $nugetPackageVersion = "${{ steps.get-configurations.outputs.pac-cli-version }}"
+        $outFolder = "pac"
 
-          $appInsightsKeyFileContent = Get-Content $appInsightsKeyFilePath | ConvertFrom-Json
-          Write-Host "Canvas apps instrumentation key configuration: $appInsightsKeyFileContent"
-        }
+        nuget install $nugetPackage -Version $nugetPackageVersion -OutputDirectory $outFolder
+        
+        $pacNugetFolder = Get-ChildItem $outFolder | Where-Object {$_.Name -match $nugetPackage + "."}
+
+        $pacPath = $pacNugetFolder.FullName + "/tools"
+
+        echo "POWERAPPS_CLI_PATH=$pacPath" >> $Env:GITHUB_ENV
+      shell: pwsh
+
+    # Manual pac solution pack with processCanvasApps
+    - name: Pack solution
+      run:  |
+        $env:PATH = $env:PATH + ";" + "${{ env.POWERAPPS_CLI_PATH }}"
+
+        cd Solutions/${{ inputs.solution-name }}
+
+        pac solution pack --zipfile ${{ inputs.solution-name }}.zip --processCanvasApps
+
+        Remove-Item Solutions/${{ inputs.solution-name }}/${{ inputs.solution-name }}.zip
       shell: pwsh

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -84,6 +84,4 @@ runs:
         cd Solutions/${{ inputs.solution-name }}
 
         pac solution pack --zipfile ${{ inputs.solution-name }}.zip --processCanvasApps
-
-        Remove-Item Solutions/${{ inputs.solution-name }}/${{ inputs.solution-name }}.zip
       shell: pwsh

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -64,7 +64,7 @@ runs:
     - name: PowerApps CLI setup
       run: |
         $nugetPackage = "Microsoft.PowerApps.CLI"
-        $nugetPackageVersion = "${{ steps.get-configurations.outputs.pac-cli-version }}"
+        $nugetPackageVersion = "1.10.4"
         $outFolder = "pac"
 
         nuget install $nugetPackage -Version $nugetPackageVersion -OutputDirectory $outFolder

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -12,6 +12,9 @@ inputs:
   solution-name:
     description: 'Name of the considered solution (not the Display Name)'
     required: true
+  pac-cli-version:
+      description: 'Considered version of PAC CLI for the pack of the canvas apps'
+      required: true
 
 runs:
   using: "composite"
@@ -64,7 +67,7 @@ runs:
     - name: PowerApps CLI setup
       run: |
         $nugetPackage = "Microsoft.PowerApps.CLI"
-        $nugetPackageVersion = "1.16.6"
+        $nugetPackageVersion = "${{ inputs.pac-cli-version }}"
         $outFolder = "pac"
 
         nuget install $nugetPackage -Version $nugetPackageVersion -OutputDirectory $outFolder

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -66,6 +66,7 @@ runs:
     # "Microsoft.PowerApps.CLI" setup
     - name: PowerApps CLI setup
       run: |
+        # "Microsoft.PowerApps.CLI" setup
         $nugetPackage = "Microsoft.PowerApps.CLI"
         $nugetPackageVersion = "${{ inputs.pac-cli-version }}"
         $outFolder = "pac"
@@ -84,7 +85,9 @@ runs:
       run:  |
         $env:PATH = $env:PATH + ";" + "${{ env.POWERAPPS_CLI_PATH }}"
 
+        # Go to the solution folder
         cd Solutions/${{ inputs.solution-name }}
 
+        # Execute pac solution pack to generate the latest version of the the msapp files
         pac solution pack --zipfile ${{ inputs.solution-name }}.zip --processCanvasApps
       shell: pwsh

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -51,13 +51,25 @@ runs:
           Write-Host "Set canvas apps instrumentation key for the following canvas app: $appInsightsKeyFilePath"
 
           $appInsightsKeyFileContent = Get-Content $appInsightsKeyFilePath | ConvertFrom-Json
-          Write-Host "Canvas apps instrumentation key configuration before update:"
-          $appInsightsKeyFileContent
+          Write-Host "Canvas apps instrumentation key configuration before update: $appInsightsKeyFileContent"
 
           $appInsightsKeyFileContent.InstrumentationKey = $canvasAppsInstrumentationKey
-          Write-Host "Canvas apps instrumentation key configuration after update:"
-          $appInsightsKeyFileContent
+          Write-Host "Canvas apps instrumentation key configuration after update: $appInsightsKeyFileContent"
 
           $appInsightsKeyFileContent | ConvertTo-Json | set-content $appInsightsKeyFilePath
+        }
+      shell: pwsh
+
+    # Check - Temp for test
+    - name: Check
+      run:  |
+        # For all relevant canvas apps (with an "AppInsightsKey.json" file) in the considered solution, set canvas apps instrumentation key
+        Get-ChildItem -Path "Solutions/${{ inputs.solution-name }}/CanvasApps/src" -Recurse -Filter AppInsightsKey.json | 
+        ForEach-Object {
+          $appInsightsKeyFilePath = $_.FullName
+          Write-Host "Set canvas apps instrumentation key for the following canvas app: $appInsightsKeyFilePath"
+
+          $appInsightsKeyFileContent = Get-Content $appInsightsKeyFilePath | ConvertFrom-Json
+          Write-Host "Canvas apps instrumentation key configuration: $appInsightsKeyFileContent"
         }
       shell: pwsh

--- a/.github/actions/set-canvasapps-instrumentation-key/action.yml
+++ b/.github/actions/set-canvasapps-instrumentation-key/action.yml
@@ -1,0 +1,54 @@
+# Copyright (c) 2020 Raphael Pothin.
+# Licensed under the MIT License.
+
+name: 'Set canvas apps instrumentation key'
+
+description: 'Set canvas apps instrumentation key based on a configuration for the considered environment'
+
+inputs:
+  path-to-custom-deployment-settings-file:
+    description: 'Path to custom deployment settings file (for things like canvas apps instrumentation key)'
+    required: true
+  solution-name:
+    description: 'Name of the considered solution (not the Display Name)'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    # Set canvas apps instrumentation key
+    - name: Set canvas apps instrumentation key
+      id: set-canvasapps-instrumentation-key
+      run:  |
+        # Set variables
+        Write-Host "Set variables"
+        $ConfigurationFilePath = "${{ inputs.path-to-custom-deployment-settings-file }}"
+
+        # Test the path provided to the file with the canvas apps instrumentation key
+        Write-Host "Test the path provided to the file with the canvas apps instrumentation key: $ConfigurationFilePath"
+        $testPathResult = Test-Path $ConfigurationFilePath
+        if(!$testPathResult) {
+          Write-Error -Message "Following path to configuration file not valid: $ConfigurationFilePath" -ErrorAction Stop
+        }
+
+        # Extract canvas apps instrumentation key from the configuration file
+        Write-Host "Get canvas apps instrumentation key from the configuration in the following location: $ConfigurationFilePath"
+        try {
+          Write-Host "Try to call the Get-Content command"
+          $configurations = Get-Content $ConfigurationFilePath -ErrorVariable getConfigurationError -ErrorAction Stop | ConvertFrom-Json
+
+          $canvasAppsInstrumentationKey = $configurations.canvasApps.instrumentationKey
+        }
+        catch {
+          Write-Error -Message "Error in the extraction of the canvas apps instrumentation key from the considered configuration file ($ConfigurationFilePath): $getConfigurationError" -ErrorAction Stop
+        }
+
+        # For all relevant canvas apps (with an "AppInsightsKey.json" file) in the considered solution, set canvas apps instrumentation key
+        Get-ChildItem -Path "Solutions/${{ inputs.solution-name }}/CanvasApps/src" -Recurse -Filter AppInsightsKey.json | 
+        ForEach-Object {     
+          $appInsightsKeyFilePath = $_.FullName
+          $appInsightsKeyFileContent = Get-Content $appInsightsKeyFilePath | ConvertFrom-Json
+          $appInsightsKeyFileContent.InstrumentationKey = $canvasAppsInstrumentationKe
+          $appInsightsKeyFileContent | ConvertTo-Json | set-content $appInsightsKeyFilePath
+        }
+      shell: pwsh

--- a/.github/workflows/build-managed-solution.yml
+++ b/.github/workflows/build-managed-solution.yml
@@ -32,6 +32,10 @@ on:
         default: false
         required: false
         type: boolean
+      pac-cli-version:
+        description: 'Considered version of PAC CLI for the pack of the canvas apps'
+        required: true
+        type: string
       current-date:
         description: 'Current date in YYYYMMDD format'
         required: true
@@ -104,6 +108,7 @@ jobs:
         with:
           path-to-custom-deployment-settings-file: ${{ inputs.path-to-custom-deployment-settings-file }}
           solution-name: ${{ inputs.solution-name }}
+          pac-cli-version: ${{ inputs.pac-cli-version }}
 
       # Pack the considered solution as unmanaged
       #   Microsoft action: https://github.com/microsoft/powerplatform-actions/blob/main/pack-solution/action.yml

--- a/.github/workflows/build-managed-solution.yml
+++ b/.github/workflows/build-managed-solution.yml
@@ -44,6 +44,10 @@ on:
         description: 'URL of the Build environment used to generate the managed version of the solution'
         required: true
         type: string
+      path-to-custom-deployment-settings-file:
+        description: 'Path to custom deployment settings file (for things like canvas apps sharing)'
+        required: true
+        type: string
     #secrets: inherit
       # APPLICATION_ID: Application ID that will be used to create the just-in-time Build environment
       # CLIENT_SECRET: Client secret associated to the application ID that will be used to create the just-in-time Build environment
@@ -97,6 +101,13 @@ jobs:
           git commit -m "Update version of ${{ inputs.solution-name }} solution to ${{ env.SOLUTION_VERSION }}"
           git  -c http.extraheader="AUTHORIZATION: Bearer ${{ secrets.GITHUB_TOKEN }}" push origin ${{ inputs.branch-to-checkout }}
         shell: pwsh
+
+      # Set canvas apps instrumentation key for the considered solution
+      - name: Set canvas apps instrumentation key
+        uses: ./.github/actions/set-canvasapps-instrumentation-key
+        with:
+          path-to-custom-deployment-settings-file: ${{ inputs.path-to-custom-deployment-settings-file }}
+          solution-name: ${{ inputs.solution-name }}
 
       # Pack the considered solution as unmanaged
       #   Microsoft action: https://github.com/microsoft/powerplatform-actions/blob/main/pack-solution/action.yml

--- a/.github/workflows/build-managed-solution.yml
+++ b/.github/workflows/build-managed-solution.yml
@@ -32,10 +32,6 @@ on:
         default: false
         required: false
         type: boolean
-      pac-cli-version:
-        description: 'Considered version of PAC CLI for the pack of the canvas apps'
-        required: true
-        type: string
       current-date:
         description: 'Current date in YYYYMMDD format'
         required: true

--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -36,6 +36,7 @@ jobs:
       build-environment-sku-name: ${{ steps.get-configurations.outputs.build-environment-sku-name }}
       environment-currency-name: ${{ steps.get-configurations.outputs.environment-currency-name }}
       environment-language-display-name: ${{ steps.get-configurations.outputs.environment-language-display-name }}
+      pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
       deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.deployment-settings-file-name-base }}
       custom-deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.custom-deployment-settings-file-name-base }}
       maximum-tries-for-cloud-flows-activation: ${{ steps.get-configurations.outputs.maximum-tries-for-cloud-flows-activation }}
@@ -113,6 +114,7 @@ jobs:
       branch-to-checkout: release/${{ needs.pre-job.outputs.solution-name }}/${{ needs.create-release-branch.outputs.release_version }}
       push-changes-to-branch: true
       upload-unmanaged-solution-to-github-artifact-store: true
+      pac-cli-version: ${{ needs.pre-job.outputs.pac-cli-version }}
       current-date: ${{ needs.pre-job.outputs.current-date }}
       build-environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
       path-to-custom-deployment-settings-file: './Configurations/${{ needs.pre-job.outputs.solution-name }}/${{ needs.pre-job.outputs.custom-deployment-settings-file-name-base }}_validation.json'

--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -36,7 +36,6 @@ jobs:
       build-environment-sku-name: ${{ steps.get-configurations.outputs.build-environment-sku-name }}
       environment-currency-name: ${{ steps.get-configurations.outputs.environment-currency-name }}
       environment-language-display-name: ${{ steps.get-configurations.outputs.environment-language-display-name }}
-      pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
       deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.deployment-settings-file-name-base }}
       custom-deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.custom-deployment-settings-file-name-base }}
       maximum-tries-for-cloud-flows-activation: ${{ steps.get-configurations.outputs.maximum-tries-for-cloud-flows-activation }}
@@ -114,7 +113,6 @@ jobs:
       branch-to-checkout: release/${{ needs.pre-job.outputs.solution-name }}/${{ needs.create-release-branch.outputs.release_version }}
       push-changes-to-branch: true
       upload-unmanaged-solution-to-github-artifact-store: true
-      pac-cli-version: ${{ needs.pre-job.outputs.pac-cli-version }}
       current-date: ${{ needs.pre-job.outputs.current-date }}
       build-environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
       path-to-custom-deployment-settings-file: './Configurations/${{ needs.pre-job.outputs.solution-name }}/${{ needs.pre-job.outputs.custom-deployment-settings-file-name-base }}_validation.json'

--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -117,6 +117,7 @@ jobs:
       pac-cli-version: ${{ needs.pre-job.outputs.pac-cli-version }}
       current-date: ${{ needs.pre-job.outputs.current-date }}
       build-environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
+      path-to-custom-deployment-settings-file: './Configurations/${{ needs.pre-job.outputs.solution-name }}/${{ needs.pre-job.outputs.custom-deployment-settings-file-name-base }}_validation.json'
     secrets: inherit
       # APPLICATION_ID: Application ID that will be used to create the just-in-time Build environment
       # CLIENT_SECRET: Client secret associated to the application ID that will be used to create the just-in-time Build environment

--- a/.github/workflows/export-and-unpack-solution.yml
+++ b/.github/workflows/export-and-unpack-solution.yml
@@ -80,6 +80,18 @@ jobs:
         overwrite-files: true
         process-canvas-apps: true
 
+    # ⚠ WOARKAROUND regarding a potential issue in the unpack of canvas apps with the current version of the action
+    # Unpack the unmanaged solution exported in the previous step
+    #   Microsoft action: https://github.com/microsoft/powerplatform-actions/blob/main/unpack-solution/action.yml
+    - name: Unpack unmanaged solution
+      uses: microsoft/powerplatform-actions/unpack-solution@main
+      with:
+        solution-file: out/exported/${{ github.event.inputs.solution_name }}.zip
+        solution-folder: Solutions/${{ github.event.inputs.solution_name }}
+        solution-type: 'Unmanaged'
+        overwrite-files: true
+        process-canvas-apps: true
+
     # Reset the solution version in the Solution.xml file
     - name: Set solution version
       run: |

--- a/.github/workflows/export-and-unpack-solution.yml
+++ b/.github/workflows/export-and-unpack-solution.yml
@@ -83,14 +83,14 @@ jobs:
     # ⚠ WOARKAROUND regarding a potential issue in the unpack of canvas apps with the current version of the action
     # Unpack the unmanaged solution exported in the previous step
     #   Microsoft action: https://github.com/microsoft/powerplatform-actions/blob/main/unpack-solution/action.yml
-    - name: Unpack unmanaged solution
-      uses: microsoft/powerplatform-actions/unpack-solution@main
-      with:
-        solution-file: out/exported/${{ github.event.inputs.solution_name }}.zip
-        solution-folder: Solutions/${{ github.event.inputs.solution_name }}
-        solution-type: 'Unmanaged'
-        overwrite-files: true
-        process-canvas-apps: true
+    #- name: Unpack unmanaged solution
+      #uses: microsoft/powerplatform-actions/unpack-solution@main
+      #with:
+        #solution-file: out/exported/${{ github.event.inputs.solution_name }}.zip
+        #solution-folder: Solutions/${{ github.event.inputs.solution_name }}
+        #solution-type: 'Unmanaged'
+        #overwrite-files: true
+        #process-canvas-apps: true
 
     # Reset the solution version in the Solution.xml file
     - name: Set solution version

--- a/.github/workflows/export-and-unpack-solution.yml
+++ b/.github/workflows/export-and-unpack-solution.yml
@@ -83,14 +83,14 @@ jobs:
     # ⚠ WOARKAROUND regarding a potential issue in the unpack of canvas apps with the current version of the action
     # Unpack the unmanaged solution exported in the previous step
     #   Microsoft action: https://github.com/microsoft/powerplatform-actions/blob/main/unpack-solution/action.yml
-    #- name: Unpack unmanaged solution
-      #uses: microsoft/powerplatform-actions/unpack-solution@main
-      #with:
-        #solution-file: out/exported/${{ github.event.inputs.solution_name }}.zip
-        #solution-folder: Solutions/${{ github.event.inputs.solution_name }}
-        #solution-type: 'Unmanaged'
-        #overwrite-files: true
-        #process-canvas-apps: true
+    - name: Unpack unmanaged solution
+      uses: microsoft/powerplatform-actions/unpack-solution@main
+      with:
+        solution-file: out/exported/${{ github.event.inputs.solution_name }}.zip
+        solution-folder: Solutions/${{ github.event.inputs.solution_name }}
+        solution-type: 'Unmanaged'
+        overwrite-files: true
+        process-canvas-apps: true
 
     # Reset the solution version in the Solution.xml file
     - name: Set solution version

--- a/.github/workflows/import-solution-to-validation.yml
+++ b/.github/workflows/import-solution-to-validation.yml
@@ -41,7 +41,6 @@ jobs:
       build-environment-sku-name: ${{ steps.get-configurations.outputs.build-environment-sku-name }}
       environment-currency-name: ${{ steps.get-configurations.outputs.environment-currency-name }}
       environment-language-display-name: ${{ steps.get-configurations.outputs.environment-language-display-name }}
-      pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
       deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.deployment-settings-file-name-base }}
       custom-deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.custom-deployment-settings-file-name-base }}
       maximum-tries-for-cloud-flows-activation: ${{ steps.get-configurations.outputs.maximum-tries-for-cloud-flows-activation }}
@@ -88,7 +87,6 @@ jobs:
     uses: ./.github/workflows/build-managed-solution.yml
     with:
       solution-name: ${{ needs.pre-job.outputs.solution-name }}
-      pac-cli-version: ${{ needs.pre-job.outputs.pac-cli-version }}
       current-date: ${{ needs.pre-job.outputs.current-date }}
       build-environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
       path-to-custom-deployment-settings-file: './Configurations/${{ needs.pre-job.outputs.solution-name }}/${{ needs.pre-job.outputs.custom-deployment-settings-file-name-base }}_validation.json'

--- a/.github/workflows/import-solution-to-validation.yml
+++ b/.github/workflows/import-solution-to-validation.yml
@@ -91,6 +91,7 @@ jobs:
       pac-cli-version: ${{ needs.pre-job.outputs.pac-cli-version }}
       current-date: ${{ needs.pre-job.outputs.current-date }}
       build-environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
+      path-to-custom-deployment-settings-file: './Configurations/${{ needs.pre-job.outputs.solution-name }}/${{ needs.pre-job.outputs.custom-deployment-settings-file-name-base }}_validation.json'
     secrets: inherit
       # APPLICATION_ID: Application ID that will be used to create the just-in-time Build environment
       # CLIENT_SECRET: Client secret associated to the application ID that will be used to create the just-in-time Build environment

--- a/.github/workflows/import-solution-to-validation.yml
+++ b/.github/workflows/import-solution-to-validation.yml
@@ -41,6 +41,7 @@ jobs:
       build-environment-sku-name: ${{ steps.get-configurations.outputs.build-environment-sku-name }}
       environment-currency-name: ${{ steps.get-configurations.outputs.environment-currency-name }}
       environment-language-display-name: ${{ steps.get-configurations.outputs.environment-language-display-name }}
+      pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
       deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.deployment-settings-file-name-base }}
       custom-deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.custom-deployment-settings-file-name-base }}
       maximum-tries-for-cloud-flows-activation: ${{ steps.get-configurations.outputs.maximum-tries-for-cloud-flows-activation }}
@@ -87,6 +88,7 @@ jobs:
     uses: ./.github/workflows/build-managed-solution.yml
     with:
       solution-name: ${{ needs.pre-job.outputs.solution-name }}
+      pac-cli-version: ${{ needs.pre-job.outputs.pac-cli-version }}
       current-date: ${{ needs.pre-job.outputs.current-date }}
       build-environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
       path-to-custom-deployment-settings-file: './Configurations/${{ needs.pre-job.outputs.solution-name }}/${{ needs.pre-job.outputs.custom-deployment-settings-file-name-base }}_validation.json'

--- a/.github/workflows/solution-quality-check-on-pr.yml
+++ b/.github/workflows/solution-quality-check-on-pr.yml
@@ -43,6 +43,7 @@ jobs:
       build-environment-sku-name: ${{ steps.get-configurations.outputs.build-environment-sku-name }}
       environment-currency-name: ${{ steps.get-configurations.outputs.environment-currency-name }}
       environment-language-display-name: ${{ steps.get-configurations.outputs.environment-language-display-name }}
+      pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
       custom-deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.custom-deployment-settings-file-name-base }}
       solution-checker-output-directory: ${{ steps.get-configurations.outputs.solution-checker-output-directory }}
       solution-checker-geography: ${{ steps.get-configurations.outputs.solution-checker-geography }}
@@ -92,6 +93,7 @@ jobs:
     with:
       solution-name: ${{ needs.pre-job.outputs.solution-name }}
       branch-to-checkout: ${{ github.head_ref }}
+      pac-cli-version: ${{ needs.pre-job.outputs.pac-cli-version }}
       current-date: ${{ needs.pre-job.outputs.current-date }}
       build-environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
       upload-unmanaged-solution-to-github-artifact-store: true

--- a/.github/workflows/solution-quality-check-on-pr.yml
+++ b/.github/workflows/solution-quality-check-on-pr.yml
@@ -43,7 +43,6 @@ jobs:
       build-environment-sku-name: ${{ steps.get-configurations.outputs.build-environment-sku-name }}
       environment-currency-name: ${{ steps.get-configurations.outputs.environment-currency-name }}
       environment-language-display-name: ${{ steps.get-configurations.outputs.environment-language-display-name }}
-      pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
       custom-deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.custom-deployment-settings-file-name-base }}
       solution-checker-output-directory: ${{ steps.get-configurations.outputs.solution-checker-output-directory }}
       solution-checker-geography: ${{ steps.get-configurations.outputs.solution-checker-geography }}
@@ -93,7 +92,6 @@ jobs:
     with:
       solution-name: ${{ needs.pre-job.outputs.solution-name }}
       branch-to-checkout: ${{ github.head_ref }}
-      pac-cli-version: ${{ needs.pre-job.outputs.pac-cli-version }}
       current-date: ${{ needs.pre-job.outputs.current-date }}
       build-environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
       upload-unmanaged-solution-to-github-artifact-store: true

--- a/.github/workflows/solution-quality-check-on-pr.yml
+++ b/.github/workflows/solution-quality-check-on-pr.yml
@@ -44,6 +44,7 @@ jobs:
       environment-currency-name: ${{ steps.get-configurations.outputs.environment-currency-name }}
       environment-language-display-name: ${{ steps.get-configurations.outputs.environment-language-display-name }}
       pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
+      custom-deployment-settings-file-name-base: ${{ steps.get-configurations.outputs.custom-deployment-settings-file-name-base }}
       solution-checker-output-directory: ${{ steps.get-configurations.outputs.solution-checker-output-directory }}
       solution-checker-geography: ${{ steps.get-configurations.outputs.solution-checker-geography }}
       solution-checker-maximum-number-high-severity-points: ${{ steps.get-configurations.outputs.solution-checker-maximum-number-high-severity-points }}
@@ -96,6 +97,7 @@ jobs:
       current-date: ${{ needs.pre-job.outputs.current-date }}
       build-environment-url: ${{ needs.create-build-environment.outputs.build-environment-url }}
       upload-unmanaged-solution-to-github-artifact-store: true
+      path-to-custom-deployment-settings-file: './Configurations/${{ needs.pre-job.outputs.solution-name }}/${{ needs.pre-job.outputs.custom-deployment-settings-file-name-base }}_validation.json'
     secrets: inherit
       # APPLICATION_ID: Application ID that will be used to create the just-in-time Build environment
       # CLIENT_SECRET: Client secret associated to the application ID that will be used to create the just-in-time Build environment

--- a/.github/workflows/workspace-initialization.yml
+++ b/.github/workflows/workspace-initialization.yml
@@ -29,7 +29,6 @@ jobs:
       development-environment-domain-name: ${{ steps.get-configurations.outputs.development-environment-domain-name-base }}${{ github.event.issue.number }}
       development-environment-sku-name: ${{ steps.get-configurations.outputs.development-environment-sku-name }}
       developers-azure-ad-group-name: ${{ steps.get-configurations.outputs.developers-azure-ad-group-name }}
-      pac-cli-version: ${{ steps.get-configurations.outputs.pac-cli-version }}
       powerapps-maker-portal-base-url: ${{ steps.get-configurations.outputs.powerapps-maker-portal-base-url }}
     env:
       RUNNER_DEBUG: 1

--- a/Configurations/configurations.json
+++ b/Configurations/configurations.json
@@ -17,7 +17,7 @@
         }
     },
     "developmentBranchNameBase": "work/",
-    "pacCliVersion": "1.10.4",
+    "pacCliVersion": "1.16.6",
     "powerAppsMakerPortalBaseUrl": "https://make.powerapps.com/environments/",
     "deploymentSettingsFileNameBase": "DeploymentSettings",
     "customDeploymentSettingsFileNameBase": "CustomDeploymentSettings",

--- a/Documentation/Custom-Deployment-Settings-File-Management.md
+++ b/Documentation/Custom-Deployment-Settings-File-Management.md
@@ -34,6 +34,7 @@ Using this repository, you will need to configure custom deployment settings fil
 > - *You can find the name of a canvas app in the objects of a solution in the [Power Apps maker portal](https://make.powerapps.com/) in the **Name** column*
 > - *You can find the name of the Azure AD group you want to consider in the [**Groups** section of **Azure AD**](https://portal.azure.com/#blade/Microsoft_AAD_IAM/GroupsManagementMenuBlade/AllGroups)*
 > - *Valid options for the role of a group on a canvas app are: **CanView**, **CanViewWithShare**, **CanEdit** (source [set-adminpowerapproleassignment](https://docs.microsoft.com/en-us/powershell/module/microsoft.powerapps.administration.powershell/set-adminpowerapproleassignment))*
+> - *You can find the instrumentation key of the considered Azure Application Insights in the header of the Overview page of the resource in the Azure portal*
 
 - the base of the name of custom deployment settings files is defined in the property `customDeploymentSettingsFileNameBase` in the global configuration file (`Configurations/configurations.json`)
 - the name of the custom deployment settings files must respect the following format: `<customDeploymentSettingsFileNameBase>_<environmentName>` (*ex: `CustomDeploymentSettings_validation`*)

--- a/Documentation/Custom-Deployment-Settings-File-Management.md
+++ b/Documentation/Custom-Deployment-Settings-File-Management.md
@@ -11,18 +11,23 @@ Using this repository, you will need to configure custom deployment settings fil
 - the custom deployment settings files need to respect the format below:
 
 ```json
-[
-    {
-        "canvasAppName": "app1",
-        "groupName": "sg-app-viewers",
-        "roleName": "CanView"
-    },
-    {
-        "canvasAppName": "app2",
-        "groupName": "sg-app-makers",
-        "roleName": "CanEdit"
+{
+    "canvasApps": {
+        "sharing": [
+            {
+                "canvasAppName": "app1",
+                "groupName": "sg-app-viewers",
+                "roleName": "CanView"
+            },
+            {
+                "canvasAppName": "app2",
+                "groupName": "sg-app-makers",
+                "roleName": "CanEdit"
+            }
+        ],
+        "instrumentationKey": "00000000-0000-0000-0000-000000000000"
     }
-]
+}
 ```
 
 > *Notes:*

--- a/Documentation/Repository-Content.md
+++ b/Documentation/Repository-Content.md
@@ -8,7 +8,8 @@
 
 ### Actions
 
-- [**get-configurations**](../.github/actions/get-configurations/action.yml): action to extract configuration from a JSON file respecting the format described [here](./Repository-Setup.md#5---update-global-configurations) 
+- [**get-configurations**](../.github/actions/get-configurations/action.yml): action to extract configuration from a JSON file respecting the format described [here](./Repository-Setup.md#5---update-global-configurations)
+- [**set-canvasapps-instrumentation-key**](../.github/actions/set-canvasapps-instrumentation-key/action.yml): action to set an Azure Application Insights Instrumentation Key we get from the considered custom deployment settings file (*format described [here](./Custom-Deployment-Settings-File-Management.md)*) in the source code of the canvas apps of the considered solution before packing for deployment
 
 ### Workflows
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ It contains components (GitHub workflows, PowerShell scripts...) that will help 
 ### Setup and configurations
 
 - [How to setup your repository from this template?](Documentation/Repository-Setup.md)
-- [How to configure a custom deployment settings file?](Documentation/Custom-Deployment-Settings-File-Management.md) - *for canvas apps sharing the Azure AD security groups*
+- [How to configure a custom deployment settings file?](Documentation/Custom-Deployment-Settings-File-Management.md) - *for canvas apps sharing to Azure AD security groups and configuration of an Azure Application Insights Instrumentation Key in canvas apps*
 
 ### Others
 


### PR DESCRIPTION
# Description

Monitoring of canvas apps through Azure Application Insights is a key element to achieve a good visibility on your applications in Production. But often your Azure Application Insights in Production is different from the one you use for development or tests. In this pull request, I try to provide a way to "dynamically" set the Azure Application Insights Instrumentation Key in canvas app during the packing phase of a solution for deployment.

> Other point included in this pull request: Correction of a current issue regarding the unpack and the pack of a solution if you want to process canvas apps (*work done in #221*) - **these workarounds are technical debt that will need to be address in a future issue.**

Fixed issues:
- #187 
- #221 

## Type of change

<Please check the options that are relevant.>

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - **the changes in this pull request require at least the version [1.15.3](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/#release-body-tab) of the PAC CLI (introduction of the "processCanvasApps" parameter)**
- [x] This change requires a documentation update

# How Has This Been Tested?

<Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.>

- [x] Tested in [PowerPlatform-ALM-With-GitHub-Template-Demo](https://github.com/rpothin/PowerPlatform-ALM-With-GitHub-Template-Demo) repository with the updated workflows using the new reusable workflow

# Checklist

<We encourage you to check all the options below before submitting your pull request.
This will help us verify it more quickly.>

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
